### PR TITLE
SBCOSS-601: Added access public tag for publishing to npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,6 +74,6 @@ jobs:
           npm run build-npm-package
           echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
           npm pack ./www/preview
-          npm publish project-sunbird-content-player-*
+          npm publish project-sunbird-content-player-* --access public
       
           


### PR DESCRIPTION
Added --access public flag for publishing to npm step